### PR TITLE
Sets paper size in PrinterController to a6.

### DIFF
--- a/app/controllers/PrinterController.php
+++ b/app/controllers/PrinterController.php
@@ -30,7 +30,7 @@ class PrinterController extends \BaseController {
 			        <p>'.$coupon->price.'$</p>
 			      </div>
 			    </div>'
-		);
+		)->setPaper('a6');
 		return $pdf->stream();
 	}
 

--- a/app/controllers/UsersController.php
+++ b/app/controllers/UsersController.php
@@ -84,9 +84,13 @@ class UsersController extends \BaseController {
 		
 		$initial_money = Auth::user()->coupons->sum('initial_price');
 		$money_spent = Auth::user()->coupons->sum('price');
+		if($initial_money != 0)
+		{
+			$prog_bar = ($money_spent * 100) / $initial_money;
+			return View::make('users.profile')->with('data1', $data1)->with('data2', $data2)->with('money_spent', $money_spent)->with('initial_money', $initial_money)->with('prog_bar', $prog_bar);
+		}
+		return View::make('users.profile')->with('data1', $data1)->with('data2', $data2)->with('money_spent', $money_spent);
 
-		$prog_bar = ($money_spent * 100) / $initial_money;
-		return View::make('users.profile')->with('data1', $data1)->with('data2', $data2)->with('money_spent', $money_spent)->with('initial_money', $initial_money)->with('prog_bar', $prog_bar);
 	}
 
 

--- a/app/database/migrations/2014_11_17_205644_create_users_table.php
+++ b/app/database/migrations/2014_11_17_205644_create_users_table.php
@@ -21,7 +21,6 @@ class CreateUsersTable extends Migration {
 			$newtable->string('last_name');
 			$newtable->string('email')->unique();
 			$newtable->string('type');
-			$newtable->string('avatar_path');
 			$newtable->timestamps('');
 		});
 	}

--- a/app/database/migrations/2014_12_04_133942_add_remember_token_to_users.php
+++ b/app/database/migrations/2014_12_04_133942_add_remember_token_to_users.php
@@ -14,7 +14,7 @@ class AddRememberTokenToUsers extends Migration {
 	{
 		Schema::table('users', function($table)
 		{
-			$table->rememberToken()->after('avatar_path');
+			$table->rememberToken();
 		});
 	}
 

--- a/app/views/coupons/create.blade.php
+++ b/app/views/coupons/create.blade.php
@@ -40,7 +40,7 @@
 
 		<div>
 			{{ Form::label('price', 'Discounted Price') }}
-			{{ Form::text('price') }}
+			{{ Form::text('price', null, array('readonly'=>'readonly')) }}
 
 			{{ $errors->first('price') }}
 		</div>


### PR DESCRIPTION
Fixes bug, when no coupons have been printed by a customer and we are trying to view his profile page.
Removes avatar field from users_table migration.
Removes 'after' hook from remember_token migration, that adds the field after the now deleted avatar field.
Makes price textbox in coupons_creation, readonly.

This closes #87 